### PR TITLE
Add Histogram Module to Dashboard

### DIFF
--- a/frontend/src/components/modules/HistogramModule/index.tsx
+++ b/frontend/src/components/modules/HistogramModule/index.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { Histogram, BarSeries, withParentSize, XAxis, YAxis } from '@visx/histogram';
+import { scaleLinear } from '@visx/scale';
+import dataFetchService from '../../../services/DataFetchService';
+
+const HistogramModule = withParentSize(({ parentWidth, parentHeight }) => {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    dataFetchService.getHistogramData().then((histogramData) => {
+      if (histogramData instanceof Error) {
+        console.error('Failed to fetch histogram data:', histogramData);
+      } else {
+        setData(histogramData);
+      }
+    });
+  }, []);
+
+  const xScale = scaleLinear({
+    domain: [Math.min(...data), Math.max(...data)],
+    nice: true,
+  });
+
+  const yScale = scaleLinear({
+    domain: [0, Math.max(...data.map((d) => d.count))],
+    nice: true,
+  });
+
+  return (
+    <div>
+      <Histogram
+        width={parentWidth}
+        height={parentHeight}
+        xScale={xScale}
+        yScale={yScale}
+        horizontal={false}
+      >
+        <BarSeries dataKey="Histogram" data={data} xAccessor={(d) => d.value} yAccessor={(d) => d.count} />
+        <XAxis />
+        <YAxis />
+      </Histogram>
+    </div>
+  );
+});
+
+export default HistogramModule;

--- a/frontend/src/containers/dashboard/index.tsx
+++ b/frontend/src/containers/dashboard/index.tsx
@@ -6,6 +6,7 @@ import ClassificationModule from "../../components/modules/ClassificationBarModu
 import StatisticsModule from "../../components/modules/StatisticsModule";
 import ConfusionMatrixModule from '../../components/modules/ConfusionMatrix';
 import SensitivityMatrixModule from '../../components/modules/SensitivityMatrix';
+import HistogramModule from '../../components/modules/HistogramModule';
 
 const DashboardLayout = () => {
   const theme = useMantineTheme();
@@ -16,6 +17,7 @@ const DashboardLayout = () => {
     { id: useId(), name: 'Classification', component: ClassificationModule, width: 'half' },
     { id: useId(), name: 'ConfusionMatrix', component: ConfusionMatrixModule, width: 'half' },
     { id: useId(), name: 'SensitivityMatrix', component: SensitivityMatrixModule, width: 'half' },
+    { id: useId(), name: 'Histogram', component: HistogramModule, width: 'half' },
   ];
 
   return (


### PR DESCRIPTION
Related to #4

This pull request introduces a new HistogramModule component and integrates it into the dashboard, enhancing the data visualization capabilities of the Stanford Dogs Classification Dataset dashboard.

- **Adds a new HistogramModule component**: Implements a new React component in `frontend/src/components/modules/HistogramModule/index.tsx` that utilizes `@visx/histogram` for rendering histograms. This component fetches data using a custom service and displays it in a histogram format, handling both the X and Y axis scaling.
- **Integrates HistogramModule into the dashboard**: Updates `frontend/src/containers/dashboard/index.tsx` to include the HistogramModule among the dashboard's visual components. This integration allows the histogram to be displayed alongside other existing modules such as the ClassificationModule, StatisticsModule, ConfusionMatrixModule, and SensitivityMatrixModule.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vasudev-io/StandfordDogsClassifier/issues/4?shareId=479833af-d0bb-4ab1-a7b6-06550c69981c).